### PR TITLE
Allow updating other fields when deleting

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ class UsersTable extends Table
 $this->delete($user); // $user entity is now soft deleted if UsersTable uses SoftDeleteTrait.
 ```
 
+You can have additional fields beside the softdelete field updated by providing them as `[$field => $value]` in the
+options for the delete call.
+
+```php
+$this->delete($user, ['setAdditionalFields' => ['is_active' => false]]);
+```
+This will set `deleted` to the current timestamp, and `is_active` to false.
+
 ### Restoring Soft deleted records
 
 To restore a soft deleted entity into an active state, use the `restore` method:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,15 +17,8 @@
         </testsuite>
     </testsuites>
 
-    <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener
-        class="\Cake\TestSuite\Fixture\FixtureInjector"
-        file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
+    <extensions>
+        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+    </extensions>
 
 </phpunit>

--- a/src/Model/Table/SoftDeleteTrait.php
+++ b/src/Model/Table/SoftDeleteTrait.php
@@ -86,8 +86,16 @@ trait SoftDeleteTrait {
         $conditions = (array)$entity->extract($primaryKey);
         $statement = $query->update()
             ->set([$this->getSoftDeleteField() => date('Y-m-d H:i:s')])
-            ->where($conditions)
-            ->execute();
+            ->where($conditions);
+        if (isset($options['setAdditionalFields'])) {
+            foreach ($options['setAdditionalFields'] as $field => $value) {
+                if ($field === $this->getSoftDeleteField()) {
+                    continue;
+                }
+                $statement->set([$field => $value]);
+            }
+        }
+        $statement = $statement->execute();
 
         $success = $statement->rowCount() > 0;
         if (!$success) {

--- a/tests/Fixture/PostsFixture.php
+++ b/tests/Fixture/PostsFixture.php
@@ -13,6 +13,7 @@ class PostsTable extends Table
 
     public function initialize(array $config): void
     {
+        $this->setPrimaryKey('id');
         $this->belongsTo('Users');
         $this->belongsToMany('Tags');
         $this->hasMany('PostsTags');
@@ -21,16 +22,8 @@ class PostsTable extends Table
 }
 
 
-class PostsFixture extends TestFixture {
-
-    public $fields = [
-        'id'          => ['type' => 'integer'],
-        'user_id'     => ['type' => 'integer', 'default' => '0', 'null' => false],
-        'deleted'     => ['type' => 'datetime', 'default' => null, 'null' => true],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
-    ];
+class PostsFixture extends TestFixture
+{
     public $records = [
         [
             'id'          => 1,

--- a/tests/Fixture/PostsTagsFixture.php
+++ b/tests/Fixture/PostsTagsFixture.php
@@ -15,22 +15,13 @@ class PostsTagsTable extends Table
     {
         $this->belongsTo('Tags');
         $this->belongsTo('Posts');
+        $this->setPrimaryKey('id');
     }
 }
 
 
-class PostsTagsFixture extends TestFixture {
-
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'post_id' => ['type' => 'integer'],
-        'tag_id' => ['type' => 'integer'],
-        'deleted'     => ['type' => 'datetime', 'default' => null, 'null' => true],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
-    ];
-
+class PostsTagsFixture extends TestFixture
+{
     public $records = [
         [
             'id' => 1,

--- a/tests/Fixture/Schema.php
+++ b/tests/Fixture/Schema.php
@@ -1,0 +1,49 @@
+<?php
+
+return [
+    'users' => [
+        'table' => 'users',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'posts_count' => ['type' => 'integer', 'default' => '0', 'null' => false],
+            'deleted' => ['type' => 'datetime', 'default' => null, 'null' => true],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ],
+    'posts' => [
+        'table' => 'posts',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'user_id' => ['type' => 'integer', 'default' => '0', 'null' => false],
+            'deleted' => ['type' => 'datetime', 'default' => null, 'null' => true],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ],
+    'tags' => [
+        'table' => 'tags',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'name' => ['type' => 'string'],
+            'deleted_date' => ['type' => 'datetime', 'default' => null, 'null' => true],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ],
+    'posts_tags' => [
+        'table' => 'posts_tags',
+        'columns' => [
+            'id' => ['type' => 'integer'],
+            'post_id' => ['type' => 'integer'],
+            'tag_id' => ['type' => 'integer'],
+            'deleted' => ['type' => 'datetime', 'default' => null, 'null' => true],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']]
+        ]
+    ]
+];

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -22,21 +22,13 @@ class TagsTable extends Table
             'targetForeignKey' => 'post_id'
         ]);
         $this->hasMany('PostsTags');
+        $this->setPrimaryKey('id');
     }
 }
 
 
-class TagsFixture extends TestFixture {
-
-    public $fields = [
-        'id'          => ['type' => 'integer'],
-        'name'     => ['type' => 'string'],
-        'deleted_date'     => ['type' => 'datetime', 'default' => null, 'null' => true],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
-    ];
-
+class TagsFixture extends TestFixture
+{
     public $records = [
         [
             'id' => 1,

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -17,19 +17,12 @@ class UsersTable extends Table
             'dependent'        => true,
             'cascadeCallbacks' => true,
         ]);
+        $this->setPrimaryKey('id');
     }
 }
 
-class UsersFixture extends TestFixture {
-
-    public $fields = [
-        'id'          => ['type' => 'integer'],
-        'posts_count'  => ['type' => 'integer', 'default' => '0', 'null' => false],
-        'deleted'     => ['type' => 'datetime', 'default' => null, 'null' => true],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
-    ];
+class UsersFixture extends TestFixture
+{
     public $records = [
         [
             'id'          => 1,

--- a/tests/TestCase/Model/Table/SoftDeleteTraitTest.php
+++ b/tests/TestCase/Model/Table/SoftDeleteTraitTest.php
@@ -20,12 +20,15 @@ class SoftDeleteBehaviorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = [
-        'plugin.SoftDelete.Users',
-        'plugin.SoftDelete.Posts',
-        'plugin.SoftDelete.Tags',
-        'plugin.SoftDelete.PostsTags'
-    ];
+    public function getFixtures(): array
+    {
+        return [
+            'plugin.SoftDelete.Users',
+            'plugin.SoftDelete.Posts',
+            'plugin.SoftDelete.Tags',
+            'plugin.SoftDelete.PostsTags'
+        ];
+    }
 
     /**
      * setUp method
@@ -335,5 +338,16 @@ class SoftDeleteBehaviorTest extends TestCase
         }
         $this->assertTrue($hasDeletedPostsTags);
         $this->assertTrue($hasDeletedTags);
+    }
+
+    public function testDeleteWithAdditionalFields(): void
+    {
+        $tag = $this->tagsTable->get(1);
+        $this->tagsTable->delete($tag, ['setAdditionalFields' => ['name' => 'parrot']]);
+        $this->assertNull($this->tagsTable->findById(1)->first());
+
+        $tag = $this->tagsTable->find('all', ['withDeleted'])->where(['id' => 1])->first();
+        $this->assertNotNull($tag);
+        $this->assertSame('parrot', $tag->name);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
+use Cake\TestSuite\Fixture\SchemaLoader;
 
 require_once 'vendor/autoload.php';
 
@@ -95,3 +96,6 @@ Log::setConfig([
         'file' => 'error',
     ]
 ]);
+
+$schemaLoader = new SchemaLoader();
+$schemaLoader->loadInternalFile(ROOT . 'tests/Fixture/Schema.php');


### PR DESCRIPTION
When deleting, sometimes you want to update more than just the softdelete column. This PR adds functionality to supply the fields and respective values you'd want to update as well.

It also updates the testsuite to that of >= CakePHP 4.3.